### PR TITLE
chore: update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 sudo: false
 
 php:
-  - 7.0
   - 7.1
   - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     }
   ],
   "require": {
-    "php": "^7.0",
+    "php": "^7.1",
     "illuminate/contracts": "^5.6",
     "symfony/yaml": "^4.1",
     "justinrainbow/json-schema": "^5.2"

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
   ],
   "require": {
     "php": "^7.0",
-    "illuminate/contracts": "^5.4",
-    "symfony/yaml": "^3.4",
+    "illuminate/contracts": "^5.6",
+    "symfony/yaml": "^4.1",
     "justinrainbow/json-schema": "^5.2"
   },
   "require-dev": {


### PR DESCRIPTION
Also removing support for PHP 7.0 since (1) it conflicts with the update of one dependency (2) it's going to be unsupported [within 3 months from now](https://secure.php.net/supported-versions.php).