### PR TITLE
Allow illuminate/contracts 6.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 sudo: false
 
 php:
-  - 7.1
   - 7.2
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     }
   ],
   "require": {
-    "php": "^7.1",
-    "illuminate/contracts": "^5.6",
+    "php": "^7.2",
+    "illuminate/contracts": "^6.0",
     "symfony/yaml": "^4.1",
     "justinrainbow/json-schema": "^5.2"
   },


### PR DESCRIPTION
Interface has not changed, allows you to use this library together with 6.* This fixes #5