### PR TITLE
Allow usage of "symfony/yaml" in versions 5.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   "require": {
     "php": "^7.2",
     "illuminate/contracts": "^6.0",
-    "symfony/yaml": "^4.1",
+    "symfony/yaml": "^4.1 || ^5.0",
     "justinrainbow/json-schema": "^5.2"
   },
   "require-dev": {


### PR DESCRIPTION
Hello, first let me thank you for a great library. Our company has been using it for over a year now and it has been really useful to us. 

We are now upgrading our code-base to SF5 and that is why I would like to suggest making this library compatible with "symfony/yaml" in versions 5.x.

I checked and there are only 2 places where the library is being used:
https://github.com/erasys/openapi-php/blob/master/src/Spec/v3/AbstractObject.php#L196
https://github.com/erasys/openapi-php/blob/master/src/Validator/DocumentValidator.php#L39

Both places reference the `Symfony\Component\Yaml\Yaml` class which has not changed its signature between the 4.1 and 5.x versions and thus there should not be any issues in supporting both ^4.1 and ^5.0 versions. 